### PR TITLE
Fix recording for live stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,8 @@ name - interpreted by each application
 
 ### Multi-worker live streaming
 
-Module supports multi-worker live
-streaming through automatic stream pushing
-to nginx workers. This option is toggled with
-rtmp_auto_push directive.
+This NGINX-RTMP module does not support multi-worker live
+streaming. While this feature can be enabled through rtmp_auto_push on|off directive, it is ill advised because it is incompatible with NGINX versions starting 1.7.2 and up, there for it should not be used.
 
 
 ### Example nginx.conf
@@ -333,21 +331,6 @@ rtmp_auto_push directive.
                 # Serve DASH fragments
                 root /tmp;
                 add_header Cache-Control no-cache;
-            }
-        }
-    }
-
-
-### Multi-worker streaming example
-
-    rtmp_auto_push on;
-
-    rtmp {
-        server {
-            listen 1935;
-
-            application mytv {
-                live on;
             }
         }
     }

--- a/config
+++ b/config
@@ -14,6 +14,7 @@ RTMP_CORE_MODULES="                                         \
                 ngx_rtmp_relay_module                       \
                 ngx_rtmp_exec_module                        \
                 ngx_rtmp_auto_push_module                   \
+                ngx_rtmp_auto_push_index_module             \
                 ngx_rtmp_notify_module                      \
                 ngx_rtmp_log_module                         \
                 ngx_rtmp_limit_module                       \

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -1621,8 +1621,11 @@ ngx_rtmp_dash_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
     }
 }
 
-
+#if (nginx_version >= 1011005)
+static ngx_msec_t
+#else
 static time_t
+#endif
 ngx_rtmp_dash_cleanup(void *data)
 {
     ngx_rtmp_dash_cleanup_t *cleanup = data;

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -1634,7 +1634,11 @@ ngx_rtmp_dash_cleanup(void *data)
 
     // Next callback in doubled playlist length time to make sure what all 
     // players read all segments
+#if (nginx_version >= 1011005)
+    return cleanup->playlen * 2;
+#else
     return cleanup->playlen / 500;
+#endif
 }
 
 static ngx_int_t

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -236,7 +236,6 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     static u_char              buffer[NGX_RTMP_DASH_BUFSIZE];
     static u_char              avaliable_time[NGX_RTMP_DASH_GMT_LENGTH];
     static u_char              publish_time[NGX_RTMP_DASH_GMT_LENGTH];
-    static u_char              end_time[NGX_RTMP_DASH_GMT_LENGTH];
     static u_char              buffer_depth[sizeof("P00Y00M00DT00H00M00.00S")];
     static u_char              frame_rate[(NGX_INT_T_LEN * 2) + 2];
 
@@ -268,7 +267,6 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "    type=\"dynamic\"\n"                                                   \
     "    xmlns=\"urn:mpeg:dash:schema:mpd:2011\"\n"                            \
     "    availabilityStartTime=\"%s\"\n"                                       \
-    "    availabilityEndTime=\"%s\"\n"                                         \
     "    publishTime=\"%s\"\n"                                                 \
     "    minimumUpdatePeriod=\"PT%uiS\"\n"                                     \
     "    minBufferTime=\"PT%uiS\"\n"                                           \
@@ -279,7 +277,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "    xmlns:xsi=\"http://www.w3.org/2011/XMLSchema-instance\"\n"            \
     "    xsi:schemaLocation=\"urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd\">\n" \
     "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-head:2014\"\n"          \
-    "       value=\"http://vm2.dashif.org/dash/time.txt\" />"                  \
+    "       value=\"http://vm2.dashif.org/dash/time.txt\" />\n"                \
     "  <Period start=\"PT0S\" id=\"dash\">\n"
 
 
@@ -363,22 +361,15 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
                  ngx_abs(ctx->start_time.gmtoff / 60),
                  ngx_abs(ctx->start_time.gmtoff % 60)) = 0;
 
-    if (publish_time[0] == '\0'){
+/* https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/pull/121#issuecomment-221108556 */
+//    if (publish_time[0] == '\0'){
         *ngx_sprintf(publish_time, "%s", avaliable_time) = 0;
-    }
+//    }
 
     ngx_libc_localtime(ctx->start_time.sec +
                        (ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
                         ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->duration) /
                        1000, &tm);
-
-    *ngx_sprintf(end_time, "%4d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d",
-                 tm.tm_year + 1900, tm.tm_mon + 1,
-                 tm.tm_mday, tm.tm_hour,
-                 tm.tm_min, tm.tm_sec,
-                 ctx->start_time.gmtoff < 0 ? '-' : '+',
-                 ngx_abs(ctx->start_time.gmtoff / 60),
-                 ngx_abs(ctx->start_time.gmtoff % 60)) = 0;
 
     depth_msec = (ngx_uint_t) (
                  ngx_rtmp_dash_get_frag(s, ctx->nfrags - 1)->timestamp +
@@ -397,7 +388,6 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
 
     p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_HEADER,
                      avaliable_time,
-                     end_time,
                      publish_time,
                      (ngx_uint_t) (dacf->fraglen / 1000),
                      (ngx_uint_t) (dacf->fraglen / 1000),

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,3 +24,6 @@
     * [notify_send_redirect](directives.md#notify_send_redirect)
   * Client Caching
   	* [hls_allow_client_cache](directives.md#hls_allow_client_cache)
+  * Dash MPD generation
+    * [dash_clock_compensation](directives.md#dash_clock_compensation)
+    * [dash_clock_helper_uri](directives.md#dash_clock_helper_uri)

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -110,6 +110,8 @@ Table of Contents
     * [dash_playlist_length](#dash_playlist_length)
     * [dash_nested](#dash_nested)
     * [dash_cleanup](#dash_cleanup)
+    * [dash_clock_compensation](#dash_clock_compensation)
+    * [dash_clock_helper_uri](#dash_clock_helper_uri)
 * [Access log](#access-log)
     * [access_log](#access_log)
     * [log_format](#log_format)
@@ -1603,6 +1605,45 @@ MPEG-DASH fragments and manifests from MPEG-DASH directory.
 Init fragments are deleted after stream manifest is deleted.
 ```sh
 dash_cleanup off;
+```
+
+#### dash\_clock_compensation
+Syntax: `dash_clock_compensation off|ntp|http_head|http_iso`  
+Context: rtmp, server, application  
+Default: off
+
+Toggles MPEG-DASH clock compentation element output into MPD.
+In this mode nginx provides `UTCTiming` element for MPEG-DASH manifest.
+Clock compensation provided by DASH-client if possible.
+- ntp - use NTP protocol
+- http_head - client must fetch header `Date` from URI (`dash_clock_helper_uri`)
+- http_iso - client must fetch date in ISO format from URI (`dash_clock_helper_uri`)
+
+Standard section: 4.7.2. Service Provider Requirements and Guidelines
+
+```sh
+dash\_clock_compensation off;
+```
+
+#### dash\_clock_helper_uri
+Syntax: `dash_clock_helper_uri URI`  
+Context: rtmp, server, application  
+Default: none
+
+URI helper resource for clock compensation for client.
+Clock compensation type:
+- ntp - address of NTP-server
+- http\_head - full HTTP uri
+- http\_iso - full HTTP uri
+
+Standard section: 4.7.2. Service Provider Requirements and Guidelines
+
+```sh
+dash\_clock\_helper_uri http://rtmp-server/static/time.txt;
+
+_or_
+
+dash\_clock\_helper_uri http://rtmp-server/lua/time-iso;
 ```
 
 ## Access log

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -1050,7 +1050,7 @@ ngx_rtmp_hls_open_fragment(ngx_rtmp_session_t *s, uint64_t ts,
     }
 
     // This is continuity counter for TS header
-    mpegts_cc = (ctx->nfrags + ctx->frag);
+    mpegts_cc = (ngx_uint_t)(ctx->nfrags + ctx->frag);
 
     ngx_log_debug7(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "hls: open fragment file='%s', keyfile='%s', "

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -2365,8 +2365,11 @@ ngx_rtmp_hls_cleanup_dir(ngx_str_t *ppath, ngx_msec_t playlen)
     }
 }
 
-
+#if (nginx_version >= 1011005)
+static ngx_msec_t
+#else
 static time_t
+#endif
 ngx_rtmp_hls_cleanup(void *data)
 {
     ngx_rtmp_hls_cleanup_t *cleanup = data;

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -2377,7 +2377,11 @@ ngx_rtmp_hls_cleanup(void *data)
     ngx_rtmp_hls_cleanup_dir(&cleanup->path, cleanup->playlen);
 
     // Next callback in half of playlist length time
+#if (nginx_version >= 1011005)
+    return cleanup->playlen / 2;
+#else
     return cleanup->playlen / 2000;
+#endif
 }
 
 

--- a/ngx_rtmp_auto_push_module.c
+++ b/ngx_rtmp_auto_push_module.c
@@ -93,6 +93,34 @@ ngx_module_t  ngx_rtmp_auto_push_module = {
 };
 
 
+static ngx_rtmp_module_t  ngx_rtmp_auto_push_index_module_ctx = {
+    NULL,                                   /* preconfiguration */
+    NULL,                                   /* postconfiguration */
+    NULL,                                   /* create main configuration */
+    NULL,                                   /* init main configuration */
+    NULL,                                   /* create server configuration */
+    NULL,                                   /* merge server configuration */
+    NULL,                                   /* create app configuration */
+    NULL                                    /* merge app configuration */
+};
+
+
+ngx_module_t  ngx_rtmp_auto_push_index_module = {
+    NGX_MODULE_V1,
+    &ngx_rtmp_auto_push_index_module_ctx,   /* module context */
+    NULL,                                   /* module directives */
+    NGX_RTMP_MODULE,                        /* module type */
+    NULL,                                   /* init master */
+    NULL,                                   /* init module */
+    NULL,                                   /* init process */
+    NULL,                                   /* init thread */
+    NULL,                                   /* exit thread */
+    NULL,                                   /* exit process */
+    NULL,                                   /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
 #define NGX_RTMP_AUTO_PUSH_SOCKNAME         "nginx-rtmp"
 
 
@@ -324,7 +352,7 @@ ngx_rtmp_auto_push_reconnect(ngx_event_t *ev)
 
     apcf = (ngx_rtmp_auto_push_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
                                                     ngx_rtmp_auto_push_module);
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_module);
+    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_index_module);
     if (ctx == NULL) {
         return;
     }
@@ -461,14 +489,14 @@ ngx_rtmp_auto_push_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_module);
+    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_index_module);
     if (ctx == NULL) {
         ctx = ngx_palloc(s->connection->pool,
                          sizeof(ngx_rtmp_auto_push_ctx_t));
         if (ctx == NULL) {
             goto next;
         }
-        ngx_rtmp_set_ctx(s, ctx, ngx_rtmp_auto_push_module);
+        ngx_rtmp_set_ctx(s, ctx, ngx_rtmp_auto_push_index_module);
 
     }
     ngx_memzero(ctx, sizeof(*ctx));
@@ -508,7 +536,7 @@ ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
         goto next;
     }
 
-    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_module);
+    ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_auto_push_index_module);
     if (ctx) {
         if (ctx->push_evt.timer_set) {
             ngx_del_timer(&ctx->push_evt);
@@ -532,7 +560,7 @@ ngx_rtmp_auto_push_delete_stream(ngx_rtmp_session_t *s,
                    slot, &rctx->app, &rctx->name);
 
     pctx = ngx_rtmp_get_module_ctx(rctx->publish->session,
-                                   ngx_rtmp_auto_push_module);
+                                   ngx_rtmp_auto_push_index_module);
     if (pctx == NULL) {
         goto next;
     }

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -900,7 +900,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
     if (v.level[0] != '\0') ngx_memcpy(ctx->level, v.level, sizeof(v.level));
 
-    ngx_log_debug8(NGX_LOG_DEBUG, s->connection->log, 0,
+    ngx_log_debug8(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
             "codec: data frame: "
             "width=%ui height=%ui duration=%.3f frame_rate=%.3f "
             "video=%s (%ui) audio=%s (%ui)",
@@ -909,6 +909,12 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
             ctx->video_codec_id,
             ngx_rtmp_get_audio_codec_name(ctx->audio_codec_id),
             ctx->audio_codec_id);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+            "codec: data frame: "
+            "video_rate=%.3f audio_rate=%.3f ",
+            ctx->video_data_rate, ctx->audio_data_rate
+            );
 
     switch (cacf->meta) {
         case NGX_RTMP_CODEC_META_ON:

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -454,7 +454,7 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
                         if (sl_next != 0) {
 
                             /* convert to signed: (-1)**k+1 * ceil(k/2) */
-                            sl_udelta = ngx_rtmp_bit_read_golomb(&br);
+                            sl_udelta = (ngx_uint_t)ngx_rtmp_bit_read_golomb(&br);
                             sl_delta = (sl_udelta + 1) >> 1;
                             if ((sl_udelta & 1) == 0) {
                                 sl_delta = -sl_delta;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -504,7 +504,9 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     struct sockaddr            *sa;
     ngx_rtmp_listen_t          *ls;
     struct sockaddr_in         *sin;
+#if (nginx_version >= 1011000)
     u_char                     *sa_cp;
+#endif
     ngx_rtmp_core_main_conf_t  *cmcf;
 #if (NGX_HAVE_INET6)
     struct sockaddr_in6        *sin6;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -500,8 +500,7 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     in_port_t                   port;
     ngx_str_t                  *value;
     ngx_url_t                   u;
-    ngx_uint_t                  i, m;
-    ngx_module_t              **modules;
+    ngx_uint_t                  i;
     struct sockaddr            *sa;
     ngx_rtmp_listen_t          *ls;
     struct sockaddr_in         *sin;
@@ -583,17 +582,6 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ls->socklen = u.socklen;
     ls->wildcard = u.wildcard;
     ls->ctx = cf->ctx;
-
-#if defined(nginx_version) && nginx_version >= 1009011
-    modules = cf->cycle->modules;
-#else
-    modules = ngx_modules;
-#endif
-    for (m = 0; modules[m]; m++) {
-        if (modules[m]->type != NGX_RTMP_MODULE) {
-            continue;
-        }
-    }
 
     for (i = 2; i < cf->args->nelts; i++) {
 

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -458,8 +458,7 @@ ngx_rtmp_core_application(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         module = modules[i]->ctx;
 
         if (module->create_app_conf) {
-            ctx->app_conf[modules[i]->ctx_index] =
-                                module->create_app_conf(cf);
+            ctx->app_conf[modules[i]->ctx_index] = module->create_app_conf(cf);
             if (ctx->app_conf[modules[i]->ctx_index] == NULL) {
                 return NGX_CONF_ERROR;
             }

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -557,7 +557,11 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             break;
         }
 
+#if (nginx_version >= 1011000)
+        if (ngx_memcmp(ls[i].sockaddr + off, &u.sockaddr + off, len) != 0) {
+#else
         if (ngx_memcmp(ls[i].sockaddr + off, u.sockaddr + off, len) != 0) {
+#endif
             continue;
         }
 
@@ -577,7 +581,11 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ngx_memzero(ls, sizeof(ngx_rtmp_listen_t));
 
+#if (nginx_version >= 1011000)
+    ngx_memcpy(ls->sockaddr, &u.sockaddr, u.socklen);
+#else
     ngx_memcpy(ls->sockaddr, u.sockaddr, u.socklen);
+#endif
 
     ls->socklen = u.socklen;
     ls->wildcard = u.wildcard;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -504,9 +504,6 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     struct sockaddr            *sa;
     ngx_rtmp_listen_t          *ls;
     struct sockaddr_in         *sin;
-#if (nginx_version >= 1011000)
-    u_char                     *sa_cp;
-#endif
     ngx_rtmp_core_main_conf_t  *cmcf;
 #if (NGX_HAVE_INET6)
     struct sockaddr_in6        *sin6;
@@ -561,8 +558,7 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
 #if (nginx_version >= 1011000)
-        sa_cp = (u_char *)(&u.sockaddr);
-        if (ngx_memcmp(ls[i].sockaddr + off, sa_cp + off, len) != 0) {
+        if (ngx_memcmp(ls[i].sockaddr + off, (u_char *) &u.sockaddr + off, len) != 0) {
 #else
         if (ngx_memcmp(ls[i].sockaddr + off, u.sockaddr + off, len) != 0) {
 #endif
@@ -586,8 +582,7 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_memzero(ls, sizeof(ngx_rtmp_listen_t));
 
 #if (nginx_version >= 1011000)
-    sa_cp = (u_char *)(&u.sockaddr);
-    ngx_memcpy(ls->sockaddr, sa_cp, u.socklen);
+    ngx_memcpy(ls->sockaddr, (u_char *) &u.sockaddr, u.socklen);
 #else
     ngx_memcpy(ls->sockaddr, u.sockaddr, u.socklen);
 #endif

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -504,6 +504,7 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     struct sockaddr            *sa;
     ngx_rtmp_listen_t          *ls;
     struct sockaddr_in         *sin;
+    u_char                     *sa_cp;
     ngx_rtmp_core_main_conf_t  *cmcf;
 #if (NGX_HAVE_INET6)
     struct sockaddr_in6        *sin6;
@@ -558,7 +559,8 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
 #if (nginx_version >= 1011000)
-        if (ngx_memcmp(ls[i].sockaddr + off, &u.sockaddr + off, len) != 0) {
+        sa_cp = (u_char *)(&u.sockaddr);
+        if (ngx_memcmp(ls[i].sockaddr + off, sa_cp + off, len) != 0) {
 #else
         if (ngx_memcmp(ls[i].sockaddr + off, u.sockaddr + off, len) != 0) {
 #endif
@@ -582,7 +584,8 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_memzero(ls, sizeof(ngx_rtmp_listen_t));
 
 #if (nginx_version >= 1011000)
-    ngx_memcpy(ls->sockaddr, &u.sockaddr, u.socklen);
+    sa_cp = (u_char *)(&u.sockaddr);
+    ngx_memcpy(ls->sockaddr, sa_cp, u.socklen);
 #else
     ngx_memcpy(ls->sockaddr, u.sockaddr, u.socklen);
 #endif
@@ -600,7 +603,6 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
         if (ngx_strncmp(value[i].data, "ipv6only=o", 10) == 0) {
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
-            struct sockaddr  *sa;
             u_char            buf[NGX_SOCKADDR_STRLEN];
 
             sa = (struct sockaddr *) ls->sockaddr;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -45,7 +45,7 @@ static ngx_command_t  ngx_rtmp_core_commands[] = {
       NULL },
 
     { ngx_string("listen"),
-      NGX_RTMP_SRV_CONF|NGX_CONF_TAKE12,
+      NGX_RTMP_SRV_CONF|NGX_CONF_1MORE,
       ngx_rtmp_core_listen,
       NGX_RTMP_SRV_CONF_OFFSET,
       0,

--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -1142,7 +1142,7 @@ ngx_rtmp_live_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         ngx_rtmp_free_shared_chain(cscf, data);
     }
 
-    if (rpkt) {
+    if (rpkt && !data) {
         ngx_rtmp_free_shared_chain(cscf, rpkt);
     }
 

--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -152,7 +152,7 @@ ngx_rtmp_live_create_app_conf(ngx_conf_t *cf)
 
     lacf->live = NGX_CONF_UNSET;
     lacf->nbuckets = NGX_CONF_UNSET;
-    lacf->buffer = NGX_CONF_UNSET_MSEC;
+    lacf->buffer = NGX_CONF_UNSET;
     lacf->sync = NGX_CONF_UNSET_MSEC;
     lacf->idle_timeout = NGX_CONF_UNSET_MSEC;
     lacf->interleave = NGX_CONF_UNSET;

--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -47,9 +47,9 @@ static ngx_command_t  ngx_rtmp_live_commands[] = {
 
     { ngx_string("buffer"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_msec_slot,
+      ngx_conf_set_flag_slot,
       NGX_RTMP_APP_CONF_OFFSET,
-      offsetof(ngx_rtmp_live_app_conf_t, buflen),
+      offsetof(ngx_rtmp_live_app_conf_t, buffer),
       NULL },
 
     { ngx_string("sync"),
@@ -152,7 +152,7 @@ ngx_rtmp_live_create_app_conf(ngx_conf_t *cf)
 
     lacf->live = NGX_CONF_UNSET;
     lacf->nbuckets = NGX_CONF_UNSET;
-    lacf->buflen = NGX_CONF_UNSET_MSEC;
+    lacf->buffer = NGX_CONF_UNSET_MSEC;
     lacf->sync = NGX_CONF_UNSET_MSEC;
     lacf->idle_timeout = NGX_CONF_UNSET_MSEC;
     lacf->interleave = NGX_CONF_UNSET;
@@ -174,7 +174,7 @@ ngx_rtmp_live_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->live, prev->live, 0);
     ngx_conf_merge_value(conf->nbuckets, prev->nbuckets, 1024);
-    ngx_conf_merge_msec_value(conf->buflen, prev->buflen, 0);
+    ngx_conf_merge_value(conf->buffer, prev->buffer, 0);
     ngx_conf_merge_msec_value(conf->sync, prev->sync, 300);
     ngx_conf_merge_msec_value(conf->idle_timeout, prev->idle_timeout, 0);
     ngx_conf_merge_value(conf->interleave, prev->interleave, 0);
@@ -553,7 +553,7 @@ ngx_rtmp_live_join(ngx_rtmp_session_t *s, u_char *name, unsigned publisher)
 
     (*stream)->ctx = ctx;
 
-    if (lacf->buflen) {
+    if (lacf->buffer) {
         s->out_buffer = 1;
     }
 

--- a/ngx_rtmp_live_module.h
+++ b/ngx_rtmp_live_module.h
@@ -72,7 +72,7 @@ typedef struct {
     ngx_flag_t                          publish_notify;
     ngx_flag_t                          play_restart;
     ngx_flag_t                          idle_streams;
-    ngx_msec_t                          buflen;
+    ngx_flag_t                          buffer;
     ngx_pool_t                         *pool;
     ngx_rtmp_live_stream_t             *free_streams;
 } ngx_rtmp_live_app_conf_t;

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -1428,14 +1428,57 @@ ngx_rtmp_notify_play_handle(ngx_rtmp_session_t *s,
     if (ngx_strncasecmp(name, (u_char *) "rtmp://", 7)) {
         *ngx_cpymem(v->name, name, rc) = 0;
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-                      "notify: play redirect to '%s'", v->name);
+                      "notify: play internal redirect to '%s'", v->name);
         goto next;
     }
 
     /* pull */
 
     nacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_notify_module);
-    if (nacf->relay_redirect) {
+    if (nacf->send_redirect) {
+        // Send 302 redirect and go next
+
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                  "notify: play send 302 redirect");
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                  "notify: -- for stream '%s' to new location '%*s'", v->name, rc, name);
+
+        local_name.data = ngx_palloc(s->connection->pool, rc+1);
+        local_name.len = rc;
+        *ngx_cpymem(local_name.data, name, rc) = 0;
+
+        /* MAGICK HERE */
+
+        if (!ngx_strncasecmp(s->flashver.data, (u_char *) "FMLE/", 5)) {
+            // Official method, by FMS SDK
+            send = ngx_rtmp_send_redirect_status(s, "onStatus", "Connect here", local_name);
+            send &= ngx_rtmp_send_redirect_status(s, "netStatus", "Connect here", local_name);
+
+            ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                      "notify: play send(o) status = '%ui'", send == NGX_OK);
+        } else {
+
+            // Something by rtmpdump lib
+            send = ngx_rtmp_send_redirect_status(s, "_error", "Connect here", local_name);
+
+            ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+                      "notify: play send(e) status = '%ui'", send == NGX_OK);
+        }
+
+        ngx_pfree(s->connection->pool, local_name.data);
+
+        ngx_rtmp_notify_clear_flag(s, NGX_RTMP_NOTIFY_PLAYING);
+
+        // Something by rtmpdump lib
+        send = ngx_rtmp_send_close_method(s, "close");
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+            "notify: play send(e) close method = '%ui'", send == NGX_OK);
+
+        return send;
+
+    } else if (nacf->relay_redirect) {
+        // Relay local streams, change name
+
         ngx_rtmp_notify_set_name(v->name, NGX_RTMP_MAX_NAME, name, (size_t) rc);
     }
 

--- a/ngx_rtmp_shared.c
+++ b/ngx_rtmp_shared.c
@@ -66,7 +66,8 @@ ngx_rtmp_free_shared_chain(ngx_rtmp_core_srv_conf_t *cscf, ngx_chain_t *in)
     }
 
     for (cl = in; ; cl = cl->next) {
-        if (cl->next == NULL) {
+        /* FIXME: Don't create circular chains in the first place */
+        if (cl->next == NULL || cl->next == in) {
             cl->next = cscf->free;
             cscf->free = in;
             return;


### PR DESCRIPTION
We used your fork on our NGINX server to generate thumbnails video. But the server was freezing because of an infinite loop on record file.

Wa patched the file and now it's working on production for over a month.